### PR TITLE
Subscribe next

### DIFF
--- a/src/core.lua
+++ b/src/core.lua
@@ -116,6 +116,8 @@ function readable(value, start)
   
   function self:subscribe(fn) return inner:subscribe(fn); end
   
+  function self:subscribe_next(fn) return inner:subscribe_next(fn); end
+  
   function self:derive(fn) return derived(self, fn); end
   
   function self:get()

--- a/src/core.lua
+++ b/src/core.lua
@@ -42,6 +42,22 @@ function writable(value, start)
     end
   end
   
+  function self:subscribe_next(fn)
+    subscribers[#subscribers + 1] = fn
+    if #subscribers == 1 then
+      stop = (start(function(value) self:set(value); end)) or utils.noop
+    end
+    return function()
+      for i, fn_ in ipairs(subscribers) do
+        if fn_ == fn then
+          table.remove(subscribers, i)
+          break
+        end
+      end
+      if #subscribers == 0 then stop(); stop = nil; end
+    end
+  end
+  
   function self:update(fn) self:set(fn(value)); end
   
   function self:derive(fn) return derived(self, fn); end

--- a/src/tweened.lua
+++ b/src/tweened.lua
@@ -127,6 +127,8 @@ function tweened(value, options)
   
   function self:subscribe(fn) return store:subscribe(fn); end
   
+  function self:subscribe_next(fn) return store:subscribe_next(fn); end
+  
   function self:get() return store:get(); end
   
   function self:monitor(fn) return core.monitor(self, fn); end


### PR DESCRIPTION
Adds the `store:subscribe_next` API. This allows the user to not subscribe to the current value in a store, but rather wait for the next one.
IE:
```lua
local my_store = awestore.writable(1)

my_store:subscribe(function(v) print(v); end)() -- Logs "1".
-- VS
do
  local unsubscribe = my_store:subscribe_next(function(v)
    print(v)
    unsubscribe()
  end)
end -- No log yet!
my_store:set(2)
-- Logs "2".
```