### PR TITLE
Subscribe once

### DIFF
--- a/src/core.lua
+++ b/src/core.lua
@@ -136,6 +136,8 @@ function readable(value, start)
   
   function self:subscribe_next(fn) return inner:subscribe_next(fn); end
   
+  function self:subscribe_once(fn) return inner:subscribe_once(fn); end
+  
   function self:derive(fn) return derived(self, fn); end
   
   function self:get()

--- a/src/core.lua
+++ b/src/core.lua
@@ -58,6 +58,15 @@ function writable(value, start)
     end
   end
   
+  function self:subscribe_once(fn)
+    local unsubscriber
+    local unsubscriber = self:subscribe_next(function(value)
+      unsubscriber()
+      fn(value)
+    end)
+    return unsubscriber
+  end
+  
   function self:update(fn) self:set(fn(value)); end
   
   function self:derive(fn) return derived(self, fn); end

--- a/src/core.lua
+++ b/src/core.lua
@@ -114,6 +114,15 @@ function signal()
     end
   end
   
+  function self:subscribe_once(fn)
+    local unsubscriber
+    unsubscriber = self:subscribe(function(value)
+      unsubscriber()
+      fn(value)
+    end)
+    return unsubscriber
+  end
+  
   function self:monitor() return signal_monitored(self); end
   
   return self

--- a/src/tweened.lua
+++ b/src/tweened.lua
@@ -129,6 +129,8 @@ function tweened(value, options)
   
   function self:subscribe_next(fn) return store:subscribe_next(fn); end
   
+  function self:subscribe_once(fn) return store:subscribe_once(fn); end
+  
   function self:get() return store:get(); end
   
   function self:monitor(fn) return core.monitor(self, fn); end


### PR DESCRIPTION
Adds the `store:subscribe_once` API.

This allows the user to unsubscribe from a store as soon as their callback has been done. Because unsubscribing from an immediate subscription is so easy (just add () after the subscription to unsubscribe it), this is a subscription to `self:subscribe_next`.

IE:

```lua
local my_store = awestore.writable(1)

-- Old
do
  local unsubscriber
  unsubscriber = my_store:subscribe(function(value)
    print(value)
    unsubscriber()
  end)
end
my_store:set(2) -- prints "2"

-- New
my_store:subscribe_once(function(value)
  print(value)
end)
my_store:set(3) -- prints "3"
```