### PR TITLE
subscribe_once impl on signal_monitor.

### DIFF
--- a/src/core.lua
+++ b/src/core.lua
@@ -92,6 +92,10 @@ function signal()
       return signal:subscribe(fn)
     end
     
+    function self:subscribe_once(fn)
+      return signal:subscribe_once(fn)
+    end
+    
     return self
   end
   


### PR DESCRIPTION
Whoops, forgot that signal has a special impl of monitor (for now).