### PR TITLE
Fix table tweening

### DIFF
--- a/src/tweened.lua
+++ b/src/tweened.lua
@@ -34,7 +34,7 @@ function get_interpolator(a, b)
     end)
   end
   
-  if type(a) == "object" then
+  if type(a) == "table" then
     local interpolators = { }
     for key, _ in pairs(b) do
       interpolators[key] = get_interpolator(a[key], b[key])


### PR DESCRIPTION
This branch fixes tweening of tables:

```lua
local my_store = awestore.tweened({
  x = 0.0,
  y = 0.0,
}, {
  duration = 2000,
  easing = quad_out,
})
```

This was broken because I did `if type(value) == "object"` instead of `if type(value) == "table"` when translating the JS code from svlete to Lua.